### PR TITLE
Bugfix/login validation

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -89,7 +89,8 @@ const LoginForm: React.FC = () => {
               required
               fullWidth
               id="name"
-              label="Name"
+              label="Enter Any Name"
+              placeholder="Enter Any Name"
               name="name"
               autoComplete="name"
               autoFocus
@@ -102,7 +103,8 @@ const LoginForm: React.FC = () => {
               required
               fullWidth
               id="email"
-              label="Email Address"
+              label="Enter Any Email"
+              placeholder="Enter Any Email"
               name="email"
               autoComplete="email"
               value={email}

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { FavoritesProvider } from '../context/FavoritesContext';
 import { ZipCodesProvider } from '../context/ZipCodesContext';
 
@@ -11,6 +11,12 @@ import Match from './Match';
 import SecondaryNavBar from '../components/Navigation/SecondaryNavBar';
 
 const MainLayout: React.FC = () => {
+  // Authentication check function
+  const isAuthenticated = () => {
+    const authData = localStorage.getItem('authData');
+    return !!authData; // Replace this with your actual authentication logic
+  };
+
   return (
     <FavoritesProvider>
       <ZipCodesProvider>
@@ -19,12 +25,16 @@ const MainLayout: React.FC = () => {
           <SecondaryNavBar />
         </header>
         <main className="flex flex-col bg-off-white font-lexend px-0 min-h-screen-minus-nav overflow-auto">
-          <Routes>
-            <Route path="/about" element={<About />} />
-            <Route path="/search" element={<Search />} />
-            <Route path="/match" element={<Match />} />
-            <Route path="/tips" element={<DogCareTips />} />
-          </Routes>
+          {isAuthenticated() ? (
+            <Routes>
+              <Route path="/about" element={<About />} />
+              <Route path="/search" element={<Search />} />
+              <Route path="/match" element={<Match />} />
+              <Route path="/tips" element={<DogCareTips />} />
+            </Routes>
+          ) : (
+            <Navigate to="/login" />
+          )}
         </main>
       </ZipCodesProvider>
     </FavoritesProvider>

--- a/src/pages/ProtectedRoute.tsx
+++ b/src/pages/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+interface ProtectedRouteProps {
+  isAuthenticated: boolean;
+  component: React.FC<any>; // Or the specific type of your components
+  // Add other prop types here if needed
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  isAuthenticated,
+  component: Component,
+  ...props
+}) => {
+  if (isAuthenticated) {
+    return <Component {...props} />;
+  } else {
+    return <Navigate to="/login" />;
+  }
+};
+
+export default ProtectedRoute;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -112,6 +112,10 @@ const APIService = {
 
   logout: async (): Promise<void> => {
     try {
+      // Clear the user's login data from local storage
+      localStorage.removeItem('authData');
+
+      // Make the logout API call
       await apiInstance.post('/auth/logout');
       console.log('Logout successful');
     } catch (error) {


### PR DESCRIPTION
**Issue:** After the user logged out, user can still access pages other than the login page by entering the route in the url.

**Expected:** User should only be able to access the login page after logged out, hitting routes of other pages should redirect back to login page if user is not authenticated.

**Fix#1:** I added to the api file (which communicate to the endpoint) a logic that deletes auth data in local storage when user log out. However, this only helped with preventing the pages from populating data from API, un-auth users can still access pages, just without data.

**Fix#2:** Added route protection logic that checks if auth data exist in local storage before accessing any route, if auth data not found user is redirected back to login page.
